### PR TITLE
Preprocess JSON error when using manual masks

### DIFF
--- a/micro_dl/cli/preprocess_script.py
+++ b/micro_dl/cli/preprocess_script.py
@@ -567,7 +567,7 @@ def pre_process(preprocess_config):
             )
             frames_meta = aux_utils.read_meta(required_params['input_dir'])
             # Automatically assign existing masks the next available channel number
-            mask_channel = (frames_meta['channel_idx'].max() + 1)
+            mask_channel = int(frames_meta['channel_idx'].max() + 1)
             mask_meta['channel_idx'] = mask_channel
             # Write metadata
             mask_meta_fname = os.path.join(mask_dir, 'frames_meta.csv')


### PR DESCRIPTION
When using manual masks the mask_channel is automatically assigned as numpy.int64 type, which throws an error when saving the process_info.json file. In this PR the type is changed to int and the process runs without errors.

![image](https://user-images.githubusercontent.com/48733135/200607802-b97b8f8a-d52a-480a-9a1e-eb854ccdc955.png)
