### PR TITLE
Add permalink to docs readme

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,3 +1,7 @@
+---
+permalink: /build/html/index.html
+---
+
 # Auto-Documentation
 
 # Sphinx


### PR DESCRIPTION
Documentation is up on github pages: https://mehta-lab.github.io/microDL/ But unfortunately it's showing the readme on how to make the docs rather than the docs themselves. I've added a permalink to the top of the readme to redirect to the index.html file. Could you please merge this change to main to I can see if it works? Thanks.