### PR TITLE
Add evaluation metrics script

### DIFF
--- a/micro_dl/cli/curator_script.py
+++ b/micro_dl/cli/curator_script.py
@@ -1,0 +1,131 @@
+# %% script to generate your ground truth directory for microDL prediction evaluation
+# After inference, the predictions generated are stored as zarr store.
+# Evaluation metrics can be computed by comparison of prediction to human proof read ground truth.
+#
+import numpy as np
+import os
+from PIL import Image
+import imagio
+import iohub.ngff as ngff
+import micro_dl.inference.evaluation_metrics as metrics
+import cellpose
+import math
+import argparse
+
+import micro_dl.utils.aux_utils as aux_utils
+
+# %% read the below details from the config file
+
+
+def parse_args():
+    """
+    Parse command line arguments
+    In python namespaces are implemented as dictionaries
+
+    :return: namespace containing the arguments passed.
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--config",
+        type=str,
+        help="path to yaml configuration file",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main(config):
+
+    """
+    pick the focus slice from n_pos number of positions, segment, and save as tifs
+    Also store the infomartion as csv file, where you can add the evaluation metrics results.
+    Info to be stored: 
+        1. position no, 
+        2. focus slice number (it will be the center slice as the images are aligned)
+        3. time point
+        4. chan name for evaluation (DAPI if nucleus)
+    """
+
+    torch_config = aux_utils.read_config(config)
+
+    zarr_dir = torch_config["data"]["data_path"]
+    pred_dir = torch_config["evaluation_metrics"]["pred_dir"]
+    ground_truth_chan = torch_config["data"]["target_channel"]
+    labelFree_chan = torch_config["data"]["source_channel"]
+    PosList = torch_config["evaluation_metrics"]["PosList"]
+    cp_model = torch_config["evaluation_metrics"]["cp_model"]
+    
+    ground_truth_subdir = "ground_truth"
+    path_split_head_tail = os.path.split(zarr_dir)
+    target_zarr_dir = path_split_head_tail[0]
+    zarr_name = path_split_head_tail[1]
+
+    os.mkdir(
+        os.path.join(target_zarr_dir, ground_truth_subdir)
+    )  # create dir to store single page tifs
+    plate = ngff.open_ome_zarr(store_path=zarr_dir, mode="r+")
+    im = plate.data
+    chan_names = plate.channel_names
+    out_shape = im.shape
+    # zarr_pos_len = reader.get_num_positions()
+    try:
+        assert len(PosList) > out_shape[0]
+    except AssertionError:
+        print(
+            "number of positions listed in config exceeds number of positions in dataset"
+        )
+
+    for pos in range(PosList):
+        raw_data = im[pos]
+        target_data = raw_data[
+            0, ground_truth_chan[0], ...
+        ]
+        Z, Y, X = np.ndarray.shape(target_data)
+        focus_idx_target = math.round((Z + 1) / 2)
+        target_focus_slice = target_data[focus_idx_target, :, :]  # FL focus slice image
+
+        im_target = Image.fromarray(
+            target_focus_slice.astype(np.uint8)
+        )  # save focus slice as single page tif
+        save_name = (
+            "_p" + str(format(pos, "03d")) + "_z" + str(format(target_focus_slice, "03d"))
+        )
+        im_target.save(
+            os.path.join(
+                target_zarr_dir,
+                ground_truth_subdir,
+                chan_names(ground_truth_chan[0]) + save_name + ".tif",
+            )
+        )
+
+        source_focus_slice = raw_data[
+            0, chan_names.index(labelFree_chan), focus_idx_target, :, :
+        ]  # lable-free focus slice image
+        im_source = Image.fromarray(
+            source_focus_slice.astype(np.uint8)
+        )  # save focus slice as single page tif
+        im_source.save(
+            os.path.join(
+                target_zarr_dir,
+                ground_truth_subdir,
+                chan_names(labelFree_chan[0]) + save_name + ".tif",
+            )
+        )  # save for reference
+
+        cp_mask = metrics.cpmask_array(
+            target_focus_slice, cp_model
+        )  # cellpose segmnetation for binary mask
+        imagio.imwrite(
+            os.path.join(
+                target_zarr_dir,
+                ground_truth_subdir,
+                labelFree_chan + save_name + "_cp_mask.png",
+            ),
+            cp_mask,
+        )  # save binary mask as numpy or png
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args.config)

--- a/micro_dl/cli/curator_script.py
+++ b/micro_dl/cli/curator_script.py
@@ -7,12 +7,13 @@ import os
 from PIL import Image
 import imagio
 import iohub.ngff as ngff
-import cellpose
 import math
 import argparse
 
 import micro_dl.inference.evaluation_metrics as metrics
 import micro_dl.utils.aux_utils as aux_utils
+from micro_dl.utils.mp_utils import add_channel
+from waveorder.focus import focus_from_transverse_band
 
 # %% read the below details from the config file
 
@@ -51,10 +52,19 @@ def main(config):
 
     zarr_dir = torch_config["data"]["data_path"]
     pred_dir = torch_config["evaluation_metrics"]["pred_dir"]
-    ground_truth_chan = torch_config["data"]["target_channel"]
+    ground_truth_chans = torch_config["data"]["target_channel"]
     labelFree_chan = torch_config["data"]["source_channel"]
     PosList = torch_config["evaluation_metrics"]["PosList"]
     cp_model = torch_config["evaluation_metrics"]["cp_model"]
+    
+    if torch_config["evaluation_metrics"]["NA_det"] is None:
+        NA_det = 1.2
+        lambda_illu = 0.532
+        pxl_sz = 6.5
+    else:
+        NA_det = torch_config["evaluation_metrics"]["NA_det"]
+        lambda_illu = torch_config["evaluation_metrics"]["lambda_illu"]
+        pxl_sz = torch_config["evaluation_metrics"]["pxl_sz"]
 
     ground_truth_subdir = "ground_truth"
     path_split_head_tail = os.path.split(zarr_dir)
@@ -76,54 +86,85 @@ def main(config):
             "number of positions listed in config exceeds number of positions in dataset"
         )
 
-    for pos in range(PosList):
-        raw_data = im[pos]
-        target_data = raw_data[
-            0, ground_truth_chan[0], ...
-        ]
-        Z, Y, X = np.ndarray.shape(target_data)
-        focus_idx_target = math.round((Z + 1) / 2)
-        target_focus_slice = target_data[focus_idx_target, :, :]  # FL focus slice image
+    for gt_chan in ground_truth_chans:
+        for pos in range(PosList):
+            raw_data = im[pos]
+            target_data = raw_data[
+                0, gt_chan.index, ...
+            ]
+            Z, Y, X = np.ndarray.shape(target_data)
+            focus_idx_target = focus_from_transverse_band(target_data,NA_det,lambda_illu,pxl_sz)
+            target_focus_slice = target_data[focus_idx_target, :, :]  # FL focus slice image
 
-        im_target = Image.fromarray(
-            target_focus_slice.astype(np.uint8)
-        )  # save focus slice as single page tif
-        save_name = (
-            "_p" + str(format(pos, "03d")) + "_z" + str(format(target_focus_slice, "03d"))
-        )
-        im_target.save(
-            os.path.join(
-                target_zarr_dir,
-                ground_truth_subdir,
-                chan_names(ground_truth_chan[0]) + save_name + ".tif",
+            im_target = Image.fromarray(
+                target_focus_slice.astype(np.uint8)
+            )  # save focus slice as single page tif
+            save_name = (
+                "_p" + str(format(pos, "03d")) + "_z" + str(format(target_focus_slice, "03d"))
             )
-        )
-
-        source_focus_slice = raw_data[
-            0, chan_names.index(labelFree_chan), focus_idx_target, :, :
-        ]  # lable-free focus slice image
-        im_source = Image.fromarray(
-            source_focus_slice.astype(np.uint8)
-        )  # save focus slice as single page tif
-        im_source.save(
-            os.path.join(
-                target_zarr_dir,
-                ground_truth_subdir,
-                chan_names(labelFree_chan[0]) + save_name + ".tif",
+            im_target.save(
+                os.path.join(
+                    target_zarr_dir,
+                    ground_truth_subdir,
+                    gt_chan + save_name + ".tif",
+                )
             )
-        )  # save for reference
 
-        cp_mask = metrics.cpmask_array(
-            target_focus_slice, cp_model
-        )  # cellpose segmnetation for binary mask
-        imagio.imwrite(
-            os.path.join(
-                target_zarr_dir,
-                ground_truth_subdir,
-                labelFree_chan + save_name + "_cp_mask.png",
-            ),
-            cp_mask,
-        )  # save binary mask as numpy or png
+            source_focus_slice = raw_data[
+                0, chan_names.index(labelFree_chan), focus_idx_target, :, :
+            ]  # lable-free focus slice image
+            im_source = Image.fromarray(
+                source_focus_slice.astype(np.uint8)
+            )  # save focus slice as single page tif
+            im_source.save(
+                os.path.join(
+                    target_zarr_dir,
+                    ground_truth_subdir,
+                    chan_names(labelFree_chan[0]) + save_name + ".tif",
+                )
+            )  # save for reference
+
+            cp_mask = metrics.cpmask_array(
+                target_focus_slice, cp_model
+            )  # cellpose segmnetation for binary mask
+            imagio.imwrite(
+                os.path.join(
+                    target_zarr_dir,
+                    ground_truth_subdir,
+                    labelFree_chan + save_name + "_cp_mask.png",
+                ),
+                cp_mask,
+            )  # save binary mask as numpy or png
+
+
+    # segment prediction and add mask as channel to pred_dir
+    pred_plate = ngff.open_ome_zarr(store_path=pred_dir, mode="r+")
+    im_pred = pred_plate.data
+    chan_names = pred_plate.channel_names
+
+    for channel_name in chan_names:
+        for i, (_, position) in enumerate(pred_plate.positions()):
+            raw_data = im_pred[position]
+            target_data = raw_data[
+                0, channel_name.index, ...
+            ]
+            
+            Z, Y, X = np.ndarray.shape(target_data)
+            new_channel_array = np.zeros(Z,Y,X)
+            for z_slice in range(Z):
+                target_slice = target_data[z_slice]
+                cp_mask = metrics.cpmask_array(
+                    target_slice, cp_model
+                ) 
+                new_channel_array[z_slice] = cp_mask
+
+            new_channel_name = channel_name + "_cp_mask"
+            add_channel(
+                position,
+                new_channel_array,
+                new_channel_name,
+            )
+
 
 
 if __name__ == "__main__":

--- a/micro_dl/cli/curator_script.py
+++ b/micro_dl/cli/curator_script.py
@@ -5,7 +5,7 @@
 import numpy as np
 import os
 from PIL import Image
-import imagio
+import imagio as iio
 import iohub.ngff as ngff
 import math
 import argparse
@@ -67,7 +67,7 @@ def main(config):
         pxl_sz = torch_config["evaluation_metrics"]["pxl_sz"]
 
     ground_truth_subdir = "ground_truth"
-    path_split_head_tail = os.path.split(zarr_dir)
+    path_split_head_tail = os.path.split(pred_dir)
     target_zarr_dir = path_split_head_tail[0]
     zarr_name = path_split_head_tail[1]
 
@@ -100,7 +100,7 @@ def main(config):
                 target_focus_slice.astype(np.uint8)
             )  # save focus slice as single page tif
             save_name = (
-                "_p" + str(format(pos, "03d")) + "_z" + str(format(target_focus_slice, "03d"))
+                "_p" + str(format(pos, "03d")) + "_z" + str(target_focus_slice)
             )
             im_target.save(
                 os.path.join(
@@ -127,11 +127,11 @@ def main(config):
             cp_mask = metrics.cpmask_array(
                 target_focus_slice, cp_model
             )  # cellpose segmnetation for binary mask
-            imagio.imwrite(
+            iio.imwrite(
                 os.path.join(
                     target_zarr_dir,
                     ground_truth_subdir,
-                    labelFree_chan + save_name + "_cp_mask.png",
+                    gt_chan + save_name + "_cp_mask.png",
                 ),
                 cp_mask,
             )  # save binary mask as numpy or png

--- a/micro_dl/cli/curator_script.py
+++ b/micro_dl/cli/curator_script.py
@@ -5,7 +5,7 @@
 import numpy as np
 import os
 from PIL import Image
-import imagio as iio
+import imageio as iio
 import iohub.ngff as ngff
 import argparse
 

--- a/micro_dl/cli/curator_script.py
+++ b/micro_dl/cli/curator_script.py
@@ -49,107 +49,114 @@ def main(config):
     ground_truth_chans = torch_config["data"]["target_channel"]
     labelFree_chan = torch_config["data"]["source_channel"]
     PosList = torch_config["evaluation_metrics"]["PosList"]
+    z_list = torch_config["evaluation_metrics"]["z_list"]
     cp_model = torch_config["evaluation_metrics"]["cp_model"]
 
-    if torch_config["evaluation_metrics"]["NA_det"] is None:
-        NA_det = 1.2
-        lambda_illu = 0.532
-        pxl_sz = 6.5
-    else:
-        NA_det = torch_config["evaluation_metrics"]["NA_det"]
-        lambda_illu = torch_config["evaluation_metrics"]["lambda_illu"]
-        pxl_sz = torch_config["evaluation_metrics"]["pxl_sz"]
+    # if torch_config["evaluation_metrics"]["NA_det"] is None:
+    #     NA_det = 1.3
+    #     lambda_illu = 0.4
+    #     pxl_sz = 0.103
+    # else:
+    #     NA_det = torch_config["evaluation_metrics"]["NA_det"]
+    #     lambda_illu = torch_config["evaluation_metrics"]["lambda_illu"]
+    #     pxl_sz = torch_config["evaluation_metrics"]["pxl_sz"]
 
     ground_truth_subdir = "ground_truth"
     path_split_head_tail = os.path.split(pred_dir)
     target_zarr_dir = path_split_head_tail[0]
     zarr_name = path_split_head_tail[1]
 
-    os.mkdir(
-        os.path.join(target_zarr_dir, ground_truth_subdir)
-    )  # create dir to store single page tifs
-    plate = ngff.open_ome_zarr(store_path=zarr_dir, mode="r+")
-    im = plate.data
-    chan_names = plate.channel_names
-    out_shape = im.shape
-    # zarr_pos_len = reader.get_num_positions()
-    try:
-        assert len(PosList) > out_shape[0]
-    except AssertionError:
-        print(
-            "number of positions listed in config exceeds number of positions in dataset"
-        )
+    if not os.path.exists(os.path.join(target_zarr_dir, ground_truth_subdir)):
+        os.mkdir(
+            os.path.join(target_zarr_dir, ground_truth_subdir)
+        )  # create dir to store single page tifs
+        plate = ngff.open_ome_zarr(store_path=zarr_dir, mode="r+")
+        chan_names = plate.channel_names
 
-    for gt_chan in ground_truth_chans:
-        for pos in range(PosList):
-            raw_data = im[pos]
-            target_data = raw_data[0, gt_chan.index, ...]
-            Z, Y, X = np.ndarray.shape(target_data)
-            focus_idx_target = focus_from_transverse_band(
-                target_data, NA_det, lambda_illu, pxl_sz
-            )
-            target_focus_slice = target_data[
-                focus_idx_target, :, :
-            ]  # FL focus slice image
-
-            im_target = Image.fromarray(
-                target_focus_slice.astype(np.uint8)
-            )  # save focus slice as single page tif
-            save_name = "_p" + str(format(pos, "03d")) + "_z" + str(target_focus_slice)
-            im_target.save(
-                os.path.join(
-                    target_zarr_dir,
-                    ground_truth_subdir,
-                    gt_chan + save_name + ".tif",
+        for i, (position, pos_data) in enumerate(plate.positions()):
+            im = pos_data.data
+            # im = plate.data
+            out_shape = im.shape
+            # zarr_pos_len = reader.get_num_positions()
+            try:
+                assert len(PosList) > out_shape[0]
+            except AssertionError:
+                print(
+                    "number of positions listed in config exceeds number of positions in dataset"
                 )
-            )
+            pos = int(position.split("/")[2])
+            for gt_chan in ground_truth_chans:
+                if pos in PosList:
+                    target_data = im[0, chan_names.index(gt_chan), ...]
+                    Z, Y, X = target_data.shape
+                    focus_idx_target = z_list[pos]
+                    # focus_idx_target = focus_from_transverse_band(
+                    #     target_data, NA_det, lambda_illu, pxl_sz
+                    # )
+                    target_focus_slice = target_data[
+                        focus_idx_target, :, :
+                    ]  # FL focus slice image
 
-            source_focus_slice = raw_data[
-                0, chan_names.index(labelFree_chan), focus_idx_target, :, :
-            ]  # lable-free focus slice image
-            im_source = Image.fromarray(
-                source_focus_slice.astype(np.uint8)
-            )  # save focus slice as single page tif
-            im_source.save(
-                os.path.join(
-                    target_zarr_dir,
-                    ground_truth_subdir,
-                    chan_names(labelFree_chan[0]) + save_name + ".tif",
-                )
-            )  # save for reference
+                    im_target = Image.fromarray(
+                        target_focus_slice
+                    )  # save focus slice as single page tif
+                    save_name = (
+                        "_p" + str(format(pos, "03d")) + "_z" + str(focus_idx_target)
+                    )
+                    im_target.save(
+                        os.path.join(
+                            target_zarr_dir,
+                            ground_truth_subdir,
+                            gt_chan + save_name + ".tif",
+                        )
+                    )
 
-            cp_mask = metrics.cpmask_array(
-                target_focus_slice, cp_model
-            )  # cellpose segmnetation for binary mask
-            iio.imwrite(
-                os.path.join(
-                    target_zarr_dir,
-                    ground_truth_subdir,
-                    gt_chan + save_name + "_cp_mask.png",
-                ),
-                cp_mask,
-            )  # save binary mask as numpy or png
+                    source_focus_slice = im[
+                        0, chan_names.index(labelFree_chan[0]), focus_idx_target, :, :
+                    ]  # lable-free focus slice image
+                    im_source = Image.fromarray(
+                        source_focus_slice
+                    )  # save focus slice as single page tif
+                    im_source.save(
+                        os.path.join(
+                            target_zarr_dir,
+                            ground_truth_subdir,
+                            labelFree_chan[0] + save_name + ".tif",
+                        )
+                    )  # save for reference
+
+                    cp_mask = metrics.cpmask_array(
+                        target_focus_slice, cp_model
+                    )  # cellpose segmnetation for binary mask
+                    iio.imwrite(
+                        os.path.join(
+                            target_zarr_dir,
+                            ground_truth_subdir,
+                            gt_chan + save_name + "_cp_mask.png",
+                        ),
+                        cp_mask,
+                    )  # save binary mask as numpy or png
 
     # segment prediction and add mask as channel to pred_dir
     pred_plate = ngff.open_ome_zarr(store_path=pred_dir, mode="r+")
-    im_pred = pred_plate.data
+    # im_pred = pred_plate.data
     chan_names = pred_plate.channel_names
 
     for channel_name in chan_names:
-        for i, (_, position) in enumerate(pred_plate.positions()):
-            raw_data = im_pred[position]
-            target_data = raw_data[0, channel_name.index, ...]
+        for i, (position, pos_data) in enumerate(pred_plate.positions()):
+            raw_data = pos_data.data
+            target_data = raw_data[0, chan_names.index(channel_name), ...]
 
-            Z, Y, X = np.ndarray.shape(target_data)
-            new_channel_array = np.zeros(Z, Y, X)
+            Z, Y, X = target_data.shape
+            new_channel_array = np.zeros((1, Z, Y, X))
             for z_slice in range(Z):
                 target_slice = target_data[z_slice]
                 cp_mask = metrics.cpmask_array(target_slice, cp_model)
-                new_channel_array[z_slice] = cp_mask
+                new_channel_array[0, z_slice] = cp_mask
 
             new_channel_name = channel_name + "_cp_mask"
             add_channel(
-                position,
+                pos_data,
                 new_channel_array,
                 new_channel_name,
             )

--- a/micro_dl/cli/curator_script.py
+++ b/micro_dl/cli/curator_script.py
@@ -73,7 +73,7 @@ def main(config):
         plate = ngff.open_ome_zarr(store_path=zarr_dir, mode="r+")
         chan_names = plate.channel_names
 
-        for i, (position, pos_data) in enumerate(plate.positions()):
+        for position, pos_data in plate.positions():
             im = pos_data.data
             # im = plate.data
             out_shape = im.shape
@@ -142,8 +142,9 @@ def main(config):
     # im_pred = pred_plate.data
     chan_names = pred_plate.channel_names
 
-    for channel_name in chan_names:
-        for i, (position, pos_data) in enumerate(pred_plate.positions()):
+    
+    for position, pos_data in pred_plate.positions():
+        for channel_name in chan_names:
             raw_data = pos_data.data
             target_data = raw_data[0, chan_names.index(channel_name), ...]
 

--- a/micro_dl/cli/curator_script.py
+++ b/micro_dl/cli/curator_script.py
@@ -7,11 +7,11 @@ import os
 from PIL import Image
 import imagio
 import iohub.ngff as ngff
-import micro_dl.inference.evaluation_metrics as metrics
 import cellpose
 import math
 import argparse
 
+import micro_dl.inference.evaluation_metrics as metrics
 import micro_dl.utils.aux_utils as aux_utils
 
 # %% read the below details from the config file
@@ -55,7 +55,7 @@ def main(config):
     labelFree_chan = torch_config["data"]["source_channel"]
     PosList = torch_config["evaluation_metrics"]["PosList"]
     cp_model = torch_config["evaluation_metrics"]["cp_model"]
-    
+
     ground_truth_subdir = "ground_truth"
     path_split_head_tail = os.path.split(zarr_dir)
     target_zarr_dir = path_split_head_tail[0]

--- a/micro_dl/cli/metrics_script.py
+++ b/micro_dl/cli/metrics_script.py
@@ -1,263 +1,132 @@
-#!/usr/bin/env/python
-
-import argparse
+# %% script to generate your ground truth directory for microDL prediction evaluation
+# After inference, the predictions generated are stored as zarr store.
+# Evaluation metrics can be computed by comparison of prediction to human proof read ground truth.
+#
 import numpy as np
 import os
+from PIL import Image
+import imagio as iio
+import iohub.ngff as ngff
+import math
+import argparse
+import glob
 import pandas as pd
-import yaml
 
 import micro_dl.inference.evaluation_metrics as metrics
 import micro_dl.utils.aux_utils as aux_utils
-import micro_dl.utils.preprocess_utils as preprocess_utils
-import micro_dl.utils.image_utils as image_utils
-import micro_dl.utils.normalize as normalize
+from micro_dl.utils.mp_utils import add_channel
+
+# %% read the below details from the config file
+
 
 def parse_args():
-    """Parse command line arguments
-
+    """
+    Parse command line arguments
     In python namespaces are implemented as dictionaries
+
     :return: namespace containing the arguments passed.
     """
-
     parser = argparse.ArgumentParser()
+
     parser.add_argument(
-        '--model_dir',
+        "--config",
         type=str,
-        required=True,
-        help='Directory containing model weights, config and csv files',
+        help="path to yaml configuration file",
     )
-    parser.add_argument(
-        '--model_fname',
-        type=str,
-        default=None,
-        help='File name of weights in model dir (.hdf5). If None grab newest.',
-    )
-    parser.add_argument(
-        '--test_data',
-        dest='test_data',
-        action='store_true',
-        help="Use test indices in split_samples.json",
-    )
-    parser.add_argument(
-        '--all_data',
-        dest='test_data',
-        action='store_false',
-    )
-    parser.set_defaults(test_data=True)
-    parser.add_argument(
-        '--image_dir',
-        type=str,
-        required=True,
-        help="Directory containing target images",
-    )
-    parser.add_argument(
-        '--metrics',
-        type=str,
-        required=True,
-        nargs='*',
-        help='Metrics for model evaluation'
-    )
-    parser.add_argument(
-        '--orientations',
-        type=str,
-        default='xyz',
-        nargs='*',
-        help='Evaluate metrics along these orientations (xy, xz, yz, xyz)'
-    )
-    parser.add_argument(
-        '--name_parser',
-        type=str,
-        default='parse_sms_name',
-        help="The function in aux_utils that will parse the file name for indices",
-    )
-    return parser.parse_args()
+    args = parser.parse_args()
+    return args
 
 
-def compute_metrics(model_dir,
-                    image_dir,
-                    metrics_list,
-                    orientations_list,
-                    output_dir = None,
-                    test_data=True,
-                    name_parser='parse_sms_name'):
+def main(config):
+
     """
-    Compute specified metrics for given orientations for predictions, which
-    are assumed to be stored in model_dir/predictions. Targets are stored in
-    image_dir.
-    Writes metrics csv files for each orientation in model_dir/predictions if
-    output_dir unspecified else output_dir/predictions.
-
-    :param str model_dir: Assumed to contain config, split_samples.json and
-        subdirectory predictions/
-    :param str image_dir: Directory containing target images with frames_meta.csv
-    :param list metrics_list: See inference/evaluation_metrics.py for options
-    :param list orientations_list: Any subset of {xy, xz, yz, xyz}
-        (see evaluation_metrics)
-    :param str/None model_dir: Directory to write metrics to, if none specied set to 
-        output_dir
-    :param bool test_data: Uses test indices in split_samples.json,
-        otherwise all indices
-    :param str name_parser: Type of name parser (default or parse_idx_from_name)
+    pick the focus slice from n_pos number of positions, segment, and save as tifs
+    Also store the infomartion as csv file, where you can add the evaluation metrics results.
+    Info to be stored: 
+        1. position no, 
+        2. focus slice number (it will be the center slice as the images are aligned)
+        3. time point
+        4. chan name for evaluation (DAPI if nucleus)
     """
 
-    
-    # Load config file
-    config_name = os.path.join(model_dir, 'config.yml')
-    with open(config_name, 'r') as f:
-        config = yaml.safe_load(f)
+    torch_config = aux_utils.read_config(config)
 
-    preprocess_config = preprocess_utils.get_preprocess_config(config['dataset']['data_dir'])
-    # Load frames metadata and determine indices
-    frames_meta = pd.read_csv(os.path.join(image_dir, 'frames_meta.csv'))
+    pred_dir = torch_config["evaluation_metrics"]["pred_dir"]
+    metric_channel = torch_config["data"]["metric_channel"]
+    PosList = torch_config["evaluation_metrics"]["PosList"]
+    metrics_list = torch_config["evaluation_metrics"]["metrics"]
 
-    if isinstance(metrics_list, str):
-        metrics_list = [metrics_list]
-    metrics_inst = metrics.MetricsEstimator(metrics_list=metrics_list)
+    ground_truth_subdir = "ground_truth"
 
-    split_idx_name = config['dataset']['split_by_column']
-    if test_data:
-        idx_fname = os.path.join(model_dir, 'split_samples.json')
-        try:
-            split_samples = aux_utils.read_json(idx_fname)
-            test_ids = np.sort(split_samples['test'])
-        except FileNotFoundError as e:
-            print("No split_samples file. Will predict all images in dir.")
-    else:
-        test_ids = np.sort(np.unique(frames_meta[split_idx_name]))
-
-    # Find other indices to iterate over than split index name
-    # E.g. if split is position, we also need to iterate over time and slice
-    test_meta = pd.read_csv(os.path.join(model_dir, 'test_metadata.csv'))
-    metadata_ids = {split_idx_name: test_ids}
-    iter_ids = ['slice_idx', 'pos_idx', 'time_idx']
-
-    for id in iter_ids:
-        if id != split_idx_name:
-            metadata_ids[id] = np.sort(np.unique(test_meta[id]))
-
-    # Create image subdirectory to write predicted images
-    if not output_dir:
-        output_dir = model_dir
-    pred_dir = os.path.join(output_dir, 'predictions')
-
-    target_channel = config['dataset']['target_channels'][0]
-
-    # If network depth is > 3 determine depth margins for +-z
-    depth = 1
-    if 'depth' in config['network']:
-        depth = config['network']['depth']
-    normalize_im = 'stack'
-    if 'normalize_im' in preprocess_config:
-        normalize_im = preprocess_config['normalize_im']
-    elif 'normalize_im' in preprocess_config['tile']:
-        normalize_im = preprocess_config['tile']['normalize_im']
-
-    # Get channel name and extension for predictions
-    parse_func = aux_utils.import_object('utils.aux_utils', name_parser, 'function')
-    pred_fnames = [f for f in os.listdir(pred_dir) if f.startswith('im')]
-    meta_row = parse_func(pred_fnames[0])
-    pred_channel = meta_row['channel_idx']
-    _, ext = os.path.splitext(pred_fnames[0])
-
-    if isinstance(orientations_list, str):
-        orientations_list = [orientations_list]
-    available_orientations = {'xy', 'xz', 'yz', 'xyz'}
-    assert set(orientations_list).issubset(available_orientations), \
-        "Orientations must be subset of {}".format(available_orientations)
-
-    fn_mapping = {
-        'xy': metrics_inst.estimate_xy_metrics,
-        'xz': metrics_inst.estimate_xz_metrics,
-        'yz': metrics_inst.estimate_yz_metrics,
-        'xyz': metrics_inst.estimate_xyz_metrics,
+    available_metrics = [
+        "ssim",
+        "corr",
+        "r2",
+        "mse",
+        "mae",
+        "acc",
+        "dice",
+        "IoU",
+        "VI",
+        "POD",
+    ]
+    metric_map = {
+        "mae_metric": metrics.mae_metric,
+        "mse_metric": metrics.mse_metric,
+        "r2_metric": metrics.r2_metric,
+        "corr_metric": metrics.corr_metric,
+        "ssim_metric": metrics.ssim_metric,
+        "acc_metric": metrics.accuracy_metric,
+        "dice_metric": metrics.dice_metric,
+        "IoU_metric": metrics.IOU_metric,
+        "VI_metric": metrics.VOI_metric,
+        "POD_metric": metrics.POD_metric,
     }
-    metrics_mapping = {
-        'xy': metrics_inst.get_metrics_xy,
-        'xz': metrics_inst.get_metrics_xz,
-        'yz': metrics_inst.get_metrics_yz,
-        'xyz': metrics_inst.get_metrics_xyz,
-    }
-    df_mapping = {
-        'xy': pd.DataFrame(),
-        'xz': pd.DataFrame(),
-        'yz': pd.DataFrame(),
-        'xyz': pd.DataFrame(),
-    }
+    d_pod = [
+        'OD_true_positives',
+        'OD_false_positives', 
+        'OD_false_negatives', 
+        'OD_precision', 
+        'OD_recall', 
+        'OD_f1_score', 
+    ]
 
-    # Iterate over all indices for test data
-    for time_idx in metadata_ids['time_idx']:
-        for pos_idx in metadata_ids['pos_idx']:
-            target_stack = []
-            pred_stack = []
-            for slice_idx in metadata_ids['slice_idx']:
-                im_idx = aux_utils.get_meta_idx(
-                    frames_metadata=frames_meta,
-                    time_idx=time_idx,
-                    channel_idx=target_channel,
-                    slice_idx=slice_idx,
-                    pos_idx=pos_idx,
-                )
-                target_fname = os.path.join(
-                    image_dir,
-                    frames_meta.loc[im_idx, 'file_name'],
-                )
-                im_target = image_utils.read_image(target_fname)
-                im_target = im_target.astype(np.float32)
+    pred_plate = ngff.open_ome_zarr(store_path=pred_dir, mode="r+")
+    im_pred = pred_plate.data
 
-                pred_fname = aux_utils.get_im_name(
-                    time_idx=time_idx,
-                    channel_idx=pred_channel,
-                    slice_idx=slice_idx,
-                    pos_idx=pos_idx,
-                    ext=ext,
-                )
-                pred_fname = os.path.join(pred_dir, pred_fname)
-                im_pred = image_utils.read_image(pred_fname)
+    metric_chan_mask = metric_channel + '_cp_mask'
+    path_split_head_tail = os.path.split(pred_dir)
+    target_zarr_dir = path_split_head_tail[0]
+    ground_truth_dir = os.path.join(target_zarr_dir,ground_truth_subdir)
 
-                # Un-zscore the predicted image. Necessary before computing SSIM
-                # if normalize_im is not None:
-                #     if normalize_im in ['dataset', 'volume', 'slice']:
-                #         zscore_median = frames_meta.loc[im_idx, 'zscore_median']
-                #         zscore_iqr = frames_meta.loc[im_idx, 'zscore_iqr']
-                #     else:
-                #         zscore_median = np.nanmean(im_target)
-                #         zscore_iqr = np.nanstd(im_target)
-                #     im_pred = normalize.unzscore(im_pred, zscore_median, zscore_iqr)
-                target_stack.append(im_target)
-                pred_stack.append(im_pred)
+    df_metrics = pd.DataFrame(columns=available_metrics[:-1]+d_pod[:-1])
 
-            target_stack = np.squeeze(np.dstack(target_stack)).astype(np.float32)
-            pred_stack = np.squeeze(np.stack(pred_stack, axis=-1)).astype(np.float32)
+    for i, (_, position) in enumerate(pred_plate.positions()):
+        raw_data = im_pred[position]
+        target_data = raw_data[
+            0, metric_chan_mask.index, ...
+        ]
 
-            pred_name = "t{}_p{}".format(time_idx, pos_idx)
-            for orientation in orientations_list:
-                print('Compute {} metrics...'.format(orientation))
-                metric_fn = fn_mapping[orientation]
-                metric_fn(
-                    target=target_stack,
-                    prediction=pred_stack,
-                    pred_name=pred_name,
-                )
-                df_mapping[orientation] = df_mapping[orientation].append(
-                    metrics_mapping[orientation](),
-                    ignore_index=True,
-                )
+        gt_mask_save_name = '^' + metric_channel + '_p' + str(format(PosList(i), "03d")) + '_z'
+        z_slice_no = int(glob.glob(ground_truth_dir + '/' + gt_mask_save_name + '*_cp_mask.png'))
+        gt_mask = iio.imread(ground_truth_dir + '/' + gt_mask_save_name + str(z_slice_no) + '_cp_mask.png')
+        pred_mask = target_data[z_slice_no]
 
-    # Save non-empty dataframes
-    for orientation in orientations_list:
-        metrics_df = df_mapping[orientation]
-        df_name = 'metrics_{}.csv'.format(orientation)
-        metrics_name = os.path.join(pred_dir, df_name)
-        metrics_df.to_csv(metrics_name, sep=",", index=False)
+        pos_metric_list = [z_slice_no]
+        for metric_name in metrics_list:
+            metric_fn = metric_map[metric_name]
+            cur_metric_list = metric_fn(
+                target=gt_mask,
+                prediction=pred_mask,
+            )
+            pos_metric_list.append(cur_metric_list)
+
+        df_metrics.loc[len(df_metrics.index)] = pos_metric_list
+
+    csv_filename = os.path.join(ground_truth_dir, 'GT_metrics.csv')
+    df_metrics.to_csv(csv_filename)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parse_args()
-    compute_metrics(
-        model_dir=args.model_dir,
-        image_dir=args.image_dir,
-        metrics_list=args.metrics,
-        orientations_list=args.orientations,
-        test_data=args.test_data,
-        name_parser=args.name_parser,
-    )
+    main(args.config)

--- a/micro_dl/cli/metrics_script.py
+++ b/micro_dl/cli/metrics_script.py
@@ -6,7 +6,6 @@ import os
 import imageio as iio
 import iohub.ngff as ngff
 import argparse
-import glob
 import pandas as pd
 
 import micro_dl.inference.evaluation_metrics as metrics
@@ -51,20 +50,8 @@ def main(config):
     z_list = torch_config["evaluation_metrics"]["z_list"]
     metrics_list = torch_config["evaluation_metrics"]["metrics"]
     ground_truth_chans = torch_config["data"]["target_channel"]
-
     ground_truth_subdir = "ground_truth"
 
-    # available_metrics = [
-    #     "ssim",
-    #     "corr",
-    #     "r2",
-    #     "mse",
-    #     "mae",
-    #     "dice",
-    #     "IoU",
-    #     "VI",
-    #     "POD",
-    # ]
     d_pod = [
         "OD_true_positives",
         "OD_false_positives",
@@ -88,16 +75,19 @@ def main(config):
 
     path_split_head_tail = os.path.split(pred_dir)
     target_zarr_dir = path_split_head_tail[0]
-    pred_plate = ngff.open_ome_zarr(store_path=os.path.join(target_zarr_dir, metric_channel + '_pred.zarr'), mode="r+")
+    pred_plate = ngff.open_ome_zarr(
+        store_path=os.path.join(target_zarr_dir, metric_channel + "_pred.zarr"),
+        mode="r+",
+    )
     chan_names = pred_plate.channel_names
     metric_chan_mask = metric_channel + "_cp_mask"
     ground_truth_dir = os.path.join(target_zarr_dir, ground_truth_subdir)
 
     col_val = metrics_list[:]
-    if 'POD' in col_val:
-        col_val.remove('POD')
+    if "POD" in col_val:
+        col_val.remove("POD")
         for i in range(len(d_pod)):
-            col_val.insert(i + metrics_list.index('POD'), d_pod[i])
+            col_val.insert(i + metrics_list.index("POD"), d_pod[i])
     df_metrics = pd.DataFrame(columns=col_val, index=PosList)
 
     for position, pos_data in pred_plate.positions():
@@ -110,12 +100,15 @@ def main(config):
 
             z_slice_no = z_list[idx]
             gt_mask_save_name = (
-                ground_truth_chans[0] + "_p" + str(format(pos, "03d")) + "_z" + str(z_slice_no) + '_cp_mask.png'
+                ground_truth_chans[0]
+                + "_p"
+                + str(format(pos, "03d"))
+                + "_z"
+                + str(z_slice_no)
+                + "_cp_mask.png"
             )
-            
-            gt_mask = iio.imread(
-                os.path.join(ground_truth_dir, gt_mask_save_name)
-            )
+
+            gt_mask = iio.imread(os.path.join(ground_truth_dir, gt_mask_save_name))
 
             pos_metric_list = []
             for metric_name in metrics_list:

--- a/micro_dl/cli/metrics_script.py
+++ b/micro_dl/cli/metrics_script.py
@@ -46,24 +46,25 @@ def main(config):
     torch_config = aux_utils.read_config(config)
 
     pred_dir = torch_config["evaluation_metrics"]["pred_dir"]
-    metric_channel = torch_config["data"]["metric_channel"]
+    metric_channel = torch_config["evaluation_metrics"]["metric_channel"]
     PosList = torch_config["evaluation_metrics"]["PosList"]
+    z_list = torch_config["evaluation_metrics"]["z_list"]
     metrics_list = torch_config["evaluation_metrics"]["metrics"]
+    ground_truth_chans = torch_config["data"]["target_channel"]
 
     ground_truth_subdir = "ground_truth"
 
-    available_metrics = [
-        "ssim",
-        "corr",
-        "r2",
-        "mse",
-        "mae",
-        "acc",
-        "dice",
-        "IoU",
-        "VI",
-        "POD",
-    ]
+    # available_metrics = [
+    #     "ssim",
+    #     "corr",
+    #     "r2",
+    #     "mse",
+    #     "mae",
+    #     "dice",
+    #     "IoU",
+    #     "VI",
+    #     "POD",
+    # ]
     d_pod = [
         "OD_true_positives",
         "OD_false_positives",
@@ -74,60 +75,58 @@ def main(config):
     ]
 
     metric_map = {
-        "mae_metric": metrics.mae_metric,
-        "mse_metric": metrics.mse_metric,
-        "r2_metric": metrics.r2_metric,
-        "corr_metric": metrics.corr_metric,
-        "ssim_metric": metrics.ssim_metric,
-        "acc_metric": metrics.accuracy_metric,
-        "dice_metric": metrics.dice_metric,
-        "IoU_metric": metrics.IOU_metric,
-        "VI_metric": metrics.VOI_metric,
-        "POD_metric": metrics.POD_metric,
+        "ssim": metrics.ssim_metric,
+        "corr": metrics.corr_metric,
+        "r2": metrics.r2_metric,
+        "mse": metrics.mse_metric,
+        "mae": metrics.mae_metric,
+        "dice": metrics.dice_metric,
+        "IoU": metrics.IOU_metric,
+        "VI": metrics.VOI_metric,
+        "POD": metrics.POD_metric,
     }
 
-    pred_plate = ngff.open_ome_zarr(store_path=pred_dir, mode="r+")
-    chan_names = pred_plate.channel_names
-
-    metric_chan_mask = metric_channel + "_cp_mask"
     path_split_head_tail = os.path.split(pred_dir)
     target_zarr_dir = path_split_head_tail[0]
+    pred_plate = ngff.open_ome_zarr(store_path=os.path.join(target_zarr_dir, metric_channel + '_pred.zarr'), mode="r+")
+    chan_names = pred_plate.channel_names
+    metric_chan_mask = metric_channel + "_cp_mask"
     ground_truth_dir = os.path.join(target_zarr_dir, ground_truth_subdir)
 
-    df_metrics = pd.DataFrame(columns=available_metrics[:-1] + d_pod[:-1])
+    col_val = metrics_list[:]
+    if 'POD' in col_val:
+        col_val.remove('POD')
+        for i in range(len(d_pod)):
+            col_val.insert(i + metrics_list.index('POD'), d_pod[i])
+    df_metrics = pd.DataFrame(columns=col_val, index=PosList)
 
-    for i, (position, pos_data) in enumerate(pred_plate.positions()):
-        pos = int(position.split("/")[2])
+    for position, pos_data in pred_plate.positions():
+        pos = int(position.split("/")[-1])
 
         if pos in PosList:
+            idx = PosList.index(pos)
             raw_data = pos_data.data
-            target_data = raw_data[0, chan_names.index(metric_chan_mask), ...]
+            pred_mask = raw_data[0, chan_names.index(metric_chan_mask)]
 
+            z_slice_no = z_list[idx]
             gt_mask_save_name = (
-                "^" + metric_channel + "_p" + str(format(pos, "03d")) + "_z"
+                ground_truth_chans[0] + "_p" + str(format(pos, "03d")) + "_z" + str(z_slice_no) + '_cp_mask.png'
             )
-            z_slice_no = int(
-                glob.glob(ground_truth_dir + "/" + gt_mask_save_name + "*_cp_mask.png")
-            )
+            
             gt_mask = iio.imread(
-                ground_truth_dir
-                + "/"
-                + gt_mask_save_name
-                + str(z_slice_no)
-                + "_cp_mask.png"
+                os.path.join(ground_truth_dir, gt_mask_save_name)
             )
-            pred_mask = target_data[z_slice_no]
 
-            pos_metric_list = [z_slice_no]
+            pos_metric_list = []
             for metric_name in metrics_list:
                 metric_fn = metric_map[metric_name]
                 cur_metric_list = metric_fn(
-                    target=gt_mask,
-                    prediction=pred_mask,
+                    gt_mask,
+                    pred_mask[0],
                 )
-                pos_metric_list.append(cur_metric_list)
+                pos_metric_list = pos_metric_list + cur_metric_list
 
-            df_metrics.loc[len(df_metrics.index)] = pos_metric_list
+            df_metrics.loc[pos] = pos_metric_list
 
     csv_filename = os.path.join(ground_truth_dir, "GT_metrics.csv")
     df_metrics.to_csv(csv_filename)

--- a/micro_dl/inference/evaluation_metrics.py
+++ b/micro_dl/inference/evaluation_metrics.py
@@ -278,9 +278,9 @@ def POD_metric(target_bin, prediction):
     distance_threshold = np.mean(lab_targ_major_axis) / 2
 
     # an uneven number of targ and pred yields zero entry row / column to make the unbalanced assignment problem balanced. The zero entries (=no realobjects) are set to nan to prevent them of being matched.
-    cost_matrix[cost_matrix==0.0] = np.nan
-    
-    #LAPsolver for minimizing cost matrix of objects
+    cost_matrix[cost_matrix == 0.0] = np.nan
+
+    # LAPsolver for minimizing cost matrix of objects
     rids, cids = solve_dense(cost_matrix)
 
     # filter out rid and cid pairs that exceed distance threshold
@@ -288,8 +288,8 @@ def POD_metric(target_bin, prediction):
     matching_pred = []
     for rid, cid in zip(rids, cids):
         if cost_matrix[rid, cid] <= distance_threshold:
-                matching_targ.append(rid)
-                matching_pred.append(cid)
+            matching_targ.append(rid)
+            matching_pred.append(cid)
 
     true_positives = len(matching_pred)
     false_positives = n_predObj - len(matching_pred)
@@ -298,7 +298,15 @@ def POD_metric(target_bin, prediction):
     recall = true_positives / (true_positives + false_negatives)
     f1_score = 2 * (precision * recall / (precision + recall))
 
-    return true_positives, false_positives, false_negatives, precision, recall, f1_score, distance_threshold
+    return (
+        true_positives,
+        false_positives,
+        false_negatives,
+        precision,
+        recall,
+        f1_score,
+        distance_threshold,
+    )
 
 
 def binarize_array(im):

--- a/micro_dl/inference/evaluation_metrics.py
+++ b/micro_dl/inference/evaluation_metrics.py
@@ -329,6 +329,7 @@ def cpmask_array(im, model_name):
     model = models.CellposeModel(model_type=model_name)
     channels = [0, 0]
     masks = model.eval(im, channels=channels, diameter=None)[0]
+    return masks
 
 
 class MetricsEstimator:

--- a/micro_dl/inference/evaluation_metrics.py
+++ b/micro_dl/inference/evaluation_metrics.py
@@ -4,7 +4,12 @@ import numpy as np
 import pandas as pd
 from skimage.metrics import structural_similarity as ssim
 import sklearn.metrics
+from skimage.morphology import disk, dilation, erosion
+from skimage.measure import label, regionprops
 from scipy.stats import pearsonr
+
+from cellpose import models, utils, io
+from lapsolver import solve_dense
 
 
 def mask_decorator(metric_function):
@@ -128,7 +133,7 @@ def ssim_metric(target, prediction, mask=None, win_size=21):
         return [cur_ssim, cur_ssim_masked]
 
 
-def accuracy_metric(target, prediction):
+def accuracy_metric(target_bin, prediction):
     """Accuracy of binary target and prediction.
     Not using mask decorator for binary data evaluation.
 
@@ -136,12 +141,12 @@ def accuracy_metric(target, prediction):
     :param np.array prediction: model prediction
     :return float Accuracy: Accuracy for binarized data
     """
-    target_bin = binarize_array(target)
-    pred_bin = binarize_array(prediction)
+    # target_bin = binarize_array(target)
+    pred_bin = cpmask_array(prediction)
     return sklearn.metrics.accuracy_score(target_bin, pred_bin)
 
 
-def dice_metric(target, prediction):
+def dice_metric(target_bin, prediction):
     """Dice similarity coefficient (F1 score) of binary target and prediction.
     Reports global metric.
     Not using mask decorator for binary data evaluation.
@@ -150,9 +155,137 @@ def dice_metric(target, prediction):
     :param np.array prediction: model prediction
     :return float dice: Dice for binarized data
     """
-    target_bin = binarize_array(target)
-    pred_bin = binarize_array(prediction)
+    # target_bin = binarize_array(target)
+    # change to reading existing ground truth masks
+    pred_bin = cpmask_array(prediction)
     return sklearn.metrics.f1_score(target_bin, pred_bin, average="micro")
+
+
+def IOU_metric(target_bin, prediction):
+    """Intersection over union metric is same as dice metric
+    Reports overlap between predicted and ground truth mask
+    : param np.array target_bin: ground truth mask
+    : param np.array prediction: model infered FL image
+    : return float IOU: IOU for image masks
+    """
+    # predicted image cellpose segmentation: output labelled mask
+    pred_bin = cpmask_array(prediction)
+
+    # convert label to binary mask
+    im_targ_mask = target_bin > 0
+    im_pred_mask = pred_bin > 0
+
+    # compute raw intersection, union and IoU
+    im_intersection = np.logical_and(im_pred_mask, im_targ_mask)
+    # im_union = (1-((1-im_pred_mask)*(1-im_targ_mask)))
+    im_union = np.logical_or(im_pred_mask, im_targ_mask)
+    IOU_ksize = [(np.sum(im_intersection) / np.sum(im_union))]
+
+    # compute intersection, union and IoU for different mask constriction
+    # mask can be too large/small due to variation in cellpose segmentation
+    # eg., defocused image has more dilated mask
+    # compute IoU at range of dilation/erosion of mask to find highest IoU
+    for k_size in range(20):
+        im_dilation = dilation(im_pred_mask, disk(k_size + 1))
+        # cv2.erode(im_pred_mask, k_size+1, iterations=1)
+        im_erosion = erosion(im_pred_mask, disk(k_size + 1))
+
+        # im_intersection = (im_pred_mask*im_targ_mask)
+        im_intersection_e = np.logical_and(im_erosion, im_targ_mask)
+        im_intersection_d = np.logical_and(im_dilation, im_targ_mask)
+
+        # im_union = (1-((1-im_pred_mask)*(1-im_targ_mask)))
+        im_union_e = np.logical_or(im_erosion, im_targ_mask)
+        im_union_d = np.logical_or(im_dilation, im_targ_mask)
+
+        # I[1] : Intersection over union
+        IOU_ksize.append(np.sum(im_intersection_d) / np.sum(im_union_d))
+        to_insert = np.sum(im_intersection_e) / np.sum(im_union_e)
+        IOU_ksize = [to_insert] + IOU_ksize
+
+    IOU = max(IOU_ksize)
+
+    return IOU.astype(np.uint8)
+
+
+def VOI_metric(target_bin, prediction):
+    # cellpose segmentation of predicted image: outputs labl mask
+    pred_bin = cpmask_array(prediction)
+
+    # convert to binary mask
+    im_targ_mask = target_bin > 0
+    im_pred_mask = pred_bin > 0
+
+    # compute entropy from pred_mask
+    marg_pred = np.histogramdd(np.ravel(im_pred_mask), bins=256)[0] / im_pred_mask.size
+    marg_pred = list(filter(lambda p: p > 0, np.ravel(marg_pred)))
+    entropy_pred = -np.sum(np.multiply(marg_pred, np.log2(marg_pred)))
+
+    # compute entropy from target_mask
+    marg_targ = np.histogramdd(np.ravel(im_targ_mask), bins=256)[0] / im_targ_mask.size
+    marg_targ = list(filter(lambda p: p > 0, np.ravel(marg_targ)))
+    entropy_targ = -np.sum(np.multiply(marg_targ, np.log2(marg_targ)))
+
+    # intersection entropy
+    im_intersection = np.logical_and(im_pred_mask, im_targ_mask)
+    im_inters_informed = im_intersection * im_targ_mask * im_pred_mask
+
+    marg_intr = (
+        np.histogramdd(np.ravel(im_inters_informed), bins=256)[0]
+        / im_inters_informed.size
+    )
+    marg_intr = list(filter(lambda p: p > 0, np.ravel(marg_intr)))
+    entropy_intr = -np.sum(np.multiply(marg_intr, np.log2(marg_intr)))
+
+    # variation of entropy/information
+    VI = entropy_pred + entropy_targ - (2 * entropy_intr)
+
+    return VI.astype(np.uint8)
+
+
+def POD_metric(target_bin, prediction):
+    pred_bin = cpmask_array(prediction)
+
+    # relabel mask for ordered labelling across images for efficient LAP mapping
+    props_pred = regionprops(label(pred_bin))
+    props_targ = regionprops(label(target_bin))
+
+    # construct empty cost matrix based on the number of objects being mapped
+    n_predObj = len(props_pred)
+    n_targObj = len(props_targ)
+    dim_cost = max(n_predObj, n_targObj)
+
+    # calculate cost based on proximity of centroid b/w objects
+    cost_matrix = np.zeros((dim_cost, dim_cost))
+    a = 0
+    b = 0
+    lab_targ = []  # enumerate the labels from labelled ground truth mask
+    lab_pred = []  # enumerate the labels from labelled predicted image mask
+    for props_t in props_targ:
+        y_t, x_t = props_t.centroid
+        lab_targ.append(props_t.label)
+        for props_p in props_pred:
+            y_p, x_p = props_p.centroid
+            lab_pred.append(props_p.label)
+            # using centroid distance as measure for mapping
+            cost_matrix[a, b] = np.sqrt(((y_t - y_p) ** 2) + ((x_t - x_p) ** 2))
+            b = b + 1
+        a = a + 1
+        b = 0
+
+    # LAPsolver for minimizing cost matrix of objects
+    rids, cids = solve_dense(cost_matrix)
+
+    # compute percent of objects detected omitting newly introduced objects and dropped objects
+    boolarr_pred = np.isin(cids, lab_pred)
+    boolarr_targ = np.isin(rids, lab_targ)
+    deaths = np.absolute(n_targObj - boolarr_targ.sum())
+    births = np.absolute(boolarr_targ.sum() - boolarr_pred.sum())
+    objects_detected = n_targObj - births - deaths
+    percent_detected = objects_detected / n_targObj
+    percent_false_detected = births
+
+    return percent_detected.astype(np.uint8), percent_false_detected.astype(np.uint8)
 
 
 def binarize_array(im):
@@ -163,6 +296,18 @@ def binarize_array(im):
     """
     im_bin = (im.flatten() / im.max()) > 0.5
     return im_bin.astype(np.uint8)
+
+
+def cpmask_array(im, model_name):
+    """mask preparation using cellpose
+
+    :input model: cellpose model used for segmentation
+    :input im: predicted image to be segmented
+    :return im_mask: cellpose segmented mask
+    """
+    model = models.CellposeModel(model_type=model_name)
+    channels = [0, 0]
+    masks = model.eval(im, channels=channels, diameter=None)[0]
 
 
 class MetricsEstimator:
@@ -184,13 +329,27 @@ class MetricsEstimator:
             'mae' -  Mean absolute error
             'acc' -  Accuracy (for binary data, no masks)
             'dice' - Dice similarity coefficient (for binary data, no masks)
+            'IoU' - Intersection over union (for binary data)
+            'VI'  - Variation of information (for binary data)
+            'POD' - Percent object detected (for label mask data)
         :param bool masked_metrics: get the metrics for the masked region
         """
 
-        available_metrics = {"ssim", "corr", "r2", "mse", "mae", "acc", "dice"}
+        available_metrics = {
+            "ssim",
+            "corr",
+            "r2",
+            "mse",
+            "mae",
+            "acc",
+            "dice",
+            "IoU",
+            "VI",
+            "POD",
+        }
         assert set(metrics_list).issubset(
             available_metrics
-        ), "only ssim, r2, corr, mse, mae, acc, dice are currently supported"
+        ), "only ssim, r2, corr, mse, mae, acc, dice, IoU, VI, POD are currently supported"
         self.metrics_list = metrics_list
         self.pd_col_names = metrics_list.copy()
         self.masked_metrics = masked_metrics
@@ -219,6 +378,9 @@ class MetricsEstimator:
             "ssim_metric": ssim_metric,
             "acc_metric": accuracy_metric,
             "dice_metric": dice_metric,
+            "IoU_metric": IOU_metric,
+            "VI_metric": VOI_metric,
+            "POD_metric": POD_metric,
         }
 
     def get_metrics_xyz(self):
@@ -324,7 +486,7 @@ class MetricsEstimator:
         metrics_row = self.compute_metrics_row(
             target=target,
             prediction=prediction,
-            pred_name=f"{pred_name}_xyz",
+            pred_name=pred_name,
             mask=mask,
         )
         # Append to existing dataframe
@@ -350,8 +512,8 @@ class MetricsEstimator:
             prediction = prediction[..., np.newaxis]
         self.metrics_xy = pd.DataFrame(columns=self.pd_col_names)
         # Loop through slices
-        for slice_idx in range(target.shape[-1]):
-            slice_name = "{}_xy".format(pred_name)
+        for slice_idx in range(target.shape[2]):
+            slice_name = "{}_xy{}".format(pred_name, slice_idx)
             cur_mask = mask[..., slice_idx] if mask is not None else None
             metrics_row = self.compute_metrics_row(
                 target=target[..., slice_idx],
@@ -377,15 +539,15 @@ class MetricsEstimator:
         """
         mask = self.mask_to_bool(mask)
         self.assert_input(target, prediction, pred_name, mask)
-        assert len(target.shape) >= 3, "Dataset is assumed to be at least 3D"
+        assert len(target.shape) == 3, "Dataset is assumed to be 3D"
         self.metrics_xz = pd.DataFrame(columns=self.pd_col_names)
         # Loop through slices
-        for slice_idx in range(target.shape[-3]):
-            slice_name = "{}_xz".format(pred_name)
+        for slice_idx in range(target.shape[0]):
+            slice_name = "{}_xz{}".format(pred_name, slice_idx)
             cur_mask = mask[slice_idx, ...] if mask is not None else None
             metrics_row = self.compute_metrics_row(
-                target=target[..., slice_idx, :, :],
-                prediction=prediction[..., slice_idx, :, :],
+                target=target[slice_idx, ...],
+                prediction=prediction[slice_idx, ...],
                 pred_name=slice_name,
                 mask=cur_mask,
             )
@@ -407,15 +569,15 @@ class MetricsEstimator:
         """
         mask = self.mask_to_bool(mask)
         self.assert_input(target, prediction, pred_name, mask)
-        assert len(target.shape) >= 3, "Dataset is assumed to be at least 3D"
+        assert len(target.shape) == 3, "Dataset is assumed to be 3D"
         self.metrics_yz = pd.DataFrame(columns=self.pd_col_names)
         # Loop through slices
-        for slice_idx in range(target.shape[-2]):
-            slice_name = "{}_yz".format(pred_name)
+        for slice_idx in range(target.shape[1]):
+            slice_name = "{}_yz{}".format(pred_name, slice_idx)
             cur_mask = mask[:, slice_idx, :] if mask is not None else None
             metrics_row = self.compute_metrics_row(
-                target=target[..., slice_idx, :],
-                prediction=prediction[..., slice_idx, :],
+                target=target[:, slice_idx, :],
+                prediction=prediction[:, slice_idx, :],
                 pred_name=slice_name,
                 mask=cur_mask,
             )

--- a/micro_dl/inference/evaluation_metrics.py
+++ b/micro_dl/inference/evaluation_metrics.py
@@ -123,6 +123,7 @@ def ssim_metric(target, prediction, win_size=21):
     )
     return [cur_ssim]
 
+
 def accuracy_metric(target_bin, pred_bin):
     """Accuracy of binary target and prediction.
     Not using mask decorator for binary data evaluation.
@@ -153,15 +154,16 @@ def dice_metric(target_bin, pred_bin):
     return [dice]
 
 
-def IOU_metric(target_bin, pred_bin):
+def IOU_metric(target, prediction):
     """Intersection over union metric is same as dice metric
     Reports overlap between predicted and ground truth mask
-    : param np.array target_bin: ground truth mask
-    : param np.array prediction: model infered FL image
+    : param np.array target: ground truth mask
+    : param np.array prediction: model infered FL image cellpose mask
     : return float IOU: IOU for image masks
     """
     # predicted image cellpose segmentation: output labelled mask
-    # pred_bin = cpmask_array(prediction)
+    pred_bin = prediction > 0
+    target_bin = target > 0
 
     # convert label to binary mask
     im_targ_mask = target_bin > 0
@@ -197,12 +199,19 @@ def IOU_metric(target_bin, pred_bin):
 
     IOU = max(IOU_ksize)
 
-    return [IOU.astype(np.uint8)]
+    return [IOU]
 
 
-def VOI_metric(target_bin, pred_bin):
+def VOI_metric(target, prediction):
+    """variation of information metric
+    Reports overlap between predicted and ground truth mask
+    : param np.array target: ground truth mask
+    : param np.array prediction: model infered FL image cellpose mask
+    : return float VI: VI for image masks
+    """
     # cellpose segmentation of predicted image: outputs labl mask
-    # pred_bin = cpmask_array(prediction)
+    pred_bin = prediction > 0
+    target_bin = target > 0
 
     # convert to binary mask
     im_targ_mask = target_bin > 0
@@ -232,7 +241,7 @@ def VOI_metric(target_bin, pred_bin):
     # variation of entropy/information
     VI = entropy_pred + entropy_targ - (2 * entropy_intr)
 
-    return [VI.astype(np.uint8)]
+    return [VI]
 
 
 def POD_metric(target_bin, pred_bin):


### PR DESCRIPTION
The evaluation metrics is computed using two scripts here. 

- `curator_script.py` creates cellpose segmented masks for target channels on the original fluorescence images which are saved as pngs and predictions, which are saved as a new channel on the zarr. 
- The user can correct the masks generated using cellpose and original fluorescence images and overwrite the masks through cellpose gui.
- `metrics_script.py` reads in both predicted image mask and user corrected ground truth mask and computes the user-listed metrics values.

I have transferred the changes created by @JohannaRahm on metrics calculation functions made in sandbox on this branch.