### PR TITLE
Determine default log directory from config

### DIFF
--- a/micro_dl/light/train.py
+++ b/micro_dl/light/train.py
@@ -15,12 +15,13 @@ class VSLightningCLI(LightningCLI):
     def add_arguments_to_parser(self, parser):
         # https://pytorch-lightning.readthedocs.io/en/1.6.0/api/pytorch_lightning.utilities.cli.html#pytorch_lightning.utilities.cli.LightningCLI.add_arguments_to_parser
         parser.link_arguments("data.batch_size", "model.batch_size")
+        parser.link_arguments("trainer.default_root_dir","trainer.logger.init_args.save_dir")
         parser.add_argument("--architecture", type=str, default="2.5D")
         parser.set_defaults(
             {
                 "trainer.logger": lazy_instance(
                     TensorBoardLogger,
-                    save_dir=os.path.expanduser('~'),  # link_arguments("trainer.default_root_dir","trainer.logger.save_dir") didn't work.
+                    save_dir="",
                     version=datetime.now().strftime(r"%Y%m%d-%H%M%S"),
                     log_graph=True,
                 )


### PR DESCRIPTION
Fix the default logging path. It should now get it from the `trainer.default_root_dir` field of the config file.

For reference, the log path can still be manually overridden in config by setting `trainer.logger.init_args.save_dir`.