### PR TITLE
Multi-GPU training

### DIFF
--- a/micro_dl/cli/fit_example.yml
+++ b/micro_dl/cli/fit_example.yml
@@ -2,7 +2,7 @@
 seed_everything: true
 trainer:
   accelerator: auto
-  strategy: auto
+  strategy: auto # ddp_find_unused_parameters_true for more GPUs
   devices: auto
   num_nodes: 1
   precision: 32-true
@@ -36,7 +36,7 @@ trainer:
   detect_anomaly: false
   barebones: false
   plugins: null
-  sync_batchnorm: false
+  sync_batchnorm: true
   reload_dataloaders_every_n_epochs: 0
   default_root_dir: null
 model:

--- a/micro_dl/light/engine.py
+++ b/micro_dl/light/engine.py
@@ -70,6 +70,7 @@ class PhaseToNuc25D(LightningModule):
             prog_bar=True,
             logger=True,
             batch_size=self.batch_size,
+            sync_dist=True,
         )
         if batch_idx < self.log_num_samples:
             self.training_step_outputs.append(
@@ -82,7 +83,7 @@ class PhaseToNuc25D(LightningModule):
         target = batch["target"]
         pred = self.forward(source)
         loss = self.loss_function(pred, target)
-        self.log("val_loss", loss, batch_size=self.batch_size)
+        self.log("val_loss", loss, batch_size=self.batch_size, sync_dist=True)
         if batch_idx < self.log_num_samples:
             self.validation_step_outputs.append(
                 self._detach_sample((source, target, pred))


### PR DESCRIPTION
Enable multi-GPU training with DDP (distributed data-parallel) strategy. I tested this on a single node with multiple GPUs, but in theory this strategy could also work for multi-node jobs should there be a need for that.

Note that different config parameters are needed. Aside from the comments in this PR, the user also needs to make sure that the number of GPUs times the number of data-loading workers is less than the available CPUs to avoid thrashing.